### PR TITLE
Adding absolute links to docs

### DIFF
--- a/_docs/building_blocks.md
+++ b/_docs/building_blocks.md
@@ -10,7 +10,7 @@ cat_order: 3
 
 Consists of a Provider Framework, a Lookup Framework, a Workflow Engine, and polyglot Language front-ends.
 
-<p align="center"><img src="buildingblocks.png" alt="Lyra"></p>
+<p align="center"><img src="https://lyraproj.github.io/docs/buildingblocks.png" alt="Lyra"></p>
 
 ## Workflow
 A Workflow describes a collection of Steps and must be declared in such a way that all input requirements of all contained activities have the potential to be fulfilled within the workflow itself.


### PR DESCRIPTION
Usiung absolute links fixes the images when they're viewed straight from the git repo